### PR TITLE
Fix broken test

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -19,7 +19,7 @@ var (
 	rawCommandArrayThree = []string{"create", "project", "stretchr", "Awesome service!"}
 	rawCommandArrayFour  = []string{"create", "account", "mat", "Crazy Brit!"}
 	rawCommandArrayFive  = []string{"create", "account", "mat", "Crazy Brit!", "localhost"}
-	rawCommandArraySix   = []string{"create", "account", "mat", "Crazy Brit!", "localhost", "127.0.0.1", "google.com"}
+	rawCommandArraySix   = []string{"create", "account", "mat", "Awesome Brit!", "localhost", "127.0.0.1", "google.com"}
 	rawCommandArraySeven = []string{"create", "account", "mat"}
 
 	cmdArray = []string{commandString, commandStringTwoOptional}

--- a/go_test.go
+++ b/go_test.go
@@ -44,7 +44,7 @@ func TestGo(t *testing.T) {
 		assert.Equal(t, len(args), 4)
 		assert.Equal(t, args["kind"], "account")
 		assert.Equal(t, args["name"], "mat")
-		assert.Equal(t, args["description"], "Crazy Brit!")
+		assert.Equal(t, args["description"], "Awesome Brit!")
 		if assert.Equal(t, len(args["domains"].([]string)), 3) {
 			domains := args["domains"].([]string)
 			assert.Equal(t, domains[0], "localhost")


### PR DESCRIPTION
2b86238d28 broke a test:

```
--- FAIL: TestCommander_execute (0.00 seconds)
        Location:       commander_test.go:73
        Error:          Not equal: "Crazy Brit!" != "Awesome Brit!"
```

Pushed "Crazy" -> "Awesome" change through to the test data so that everything passes again.
